### PR TITLE
Use bogus values in `.tool-versions`

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Test for bash
         shell: bash
         run: |
-          RUBY=${{steps.tool-versions.outputs.ruby}}
-          NPM=${{steps.tool-versions.outputs.npm}}
-          PYTHON=${{steps.tool-versions.outputs.python}}
+          RUBY=${{steps.tool-versions.outputs.example-ruby}}
+          NPM=${{steps.tool-versions.outputs.example-npm}}
+          PYTHON=${{steps.tool-versions.outputs.example-python}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"
@@ -30,9 +30,9 @@ jobs:
       - name: Test for pwsh
         shell: pwsh
         run: |
-          $Env:RUBY="${{steps.tool-versions.outputs.ruby}}"
-          $Env:NPM="${{steps.tool-versions.outputs.npm}}"
-          $Env:PYTHON="${{steps.tool-versions.outputs.python}}"
+          $Env:RUBY="${{steps.tool-versions.outputs.example-ruby}}"
+          $Env:NPM="${{steps.tool-versions.outputs.example-npm}}"
+          $Env:PYTHON="${{steps.tool-versions.outputs.example-python}}"
           Test-Path $Env:RUBY
           Test-Path $Env:NPM
           Test-Path $Env:PYTHON
@@ -40,9 +40,9 @@ jobs:
       - name: Test for sh
         shell: sh
         run: |
-          RUBY=${{steps.tool-versions.outputs.ruby}}
-          NPM=${{steps.tool-versions.outputs.npm}}
-          PYTHON=${{steps.tool-versions.outputs.python}}
+          RUBY=${{steps.tool-versions.outputs.example-ruby}}
+          NPM=${{steps.tool-versions.outputs.example-npm}}
+          PYTHON=${{steps.tool-versions.outputs.example-python}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Test for bash
         shell: bash
         run: |
-          RUBY=${{steps.tool-versions.outputs.ruby}}
-          NPM=${{steps.tool-versions.outputs.npm}}
-          PYTHON=${{steps.tool-versions.outputs.python}}
+          RUBY=${{steps.tool-versions.outputs.example-ruby}}
+          NPM=${{steps.tool-versions.outputs.example-npm}}
+          PYTHON=${{steps.tool-versions.outputs.example-python}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"
@@ -30,9 +30,9 @@ jobs:
       - name: Test for pwsh
         shell: pwsh
         run: |
-          $Env:RUBY="${{steps.tool-versions.outputs.ruby}}"
-          $Env:NPM="${{steps.tool-versions.outputs.npm}}"
-          $Env:PYTHON="${{steps.tool-versions.outputs.python}}"
+          $Env:RUBY="${{steps.tool-versions.outputs.example-ruby}}"
+          $Env:NPM="${{steps.tool-versions.outputs.example-npm}}"
+          $Env:PYTHON="${{steps.tool-versions.outputs.example-python}}"
           Test-Path $Env:RUBY
           Test-Path $Env:NPM
           Test-Path $Env:PYTHON
@@ -40,9 +40,9 @@ jobs:
       - name: Test for sh
         shell: sh
         run: |
-          RUBY=${{steps.tool-versions.outputs.ruby}}
-          NPM=${{steps.tool-versions.outputs.npm}}
-          PYTHON=${{steps.tool-versions.outputs.python}}
+          RUBY=${{steps.tool-versions.outputs.example-ruby}}
+          NPM=${{steps.tool-versions.outputs.example-npm}}
+          PYTHON=${{steps.tool-versions.outputs.example-python}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Test for bash
         shell: bash
         run: |
-          RUBY=${{steps.tool-versions.outputs.ruby}}
-          NPM=${{steps.tool-versions.outputs.npm}}
-          PYTHON=${{steps.tool-versions.outputs.python}}
+          RUBY=${{steps.tool-versions.outputs.example-ruby}}
+          NPM=${{steps.tool-versions.outputs.example-npm}}
+          PYTHON=${{steps.tool-versions.outputs.example-python}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"
@@ -30,9 +30,9 @@ jobs:
       - name: Test for pwsh
         shell: pwsh
         run: |
-          $Env:RUBY="${{steps.tool-versions.outputs.ruby}}"
-          $Env:NPM="${{steps.tool-versions.outputs.npm}}"
-          $Env:PYTHON="${{steps.tool-versions.outputs.python}}"
+          $Env:RUBY="${{steps.tool-versions.outputs.example-ruby}}"
+          $Env:NPM="${{steps.tool-versions.outputs.example-npm}}"
+          $Env:PYTHON="${{steps.tool-versions.outputs.example-python}}"
           Test-Path $Env:RUBY
           Test-Path $Env:NPM
           Test-Path $Env:PYTHON
@@ -40,9 +40,9 @@ jobs:
       - name: Test for sh
         shell: sh
         run: |
-          RUBY=${{steps.tool-versions.outputs.ruby}}
-          NPM=${{steps.tool-versions.outputs.npm}}
-          PYTHON=${{steps.tool-versions.outputs.python}}
+          RUBY=${{steps.tool-versions.outputs.example-ruby}}
+          NPM=${{steps.tool-versions.outputs.example-npm}}
+          PYTHON=${{steps.tool-versions.outputs.example-python}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"
@@ -50,9 +50,9 @@ jobs:
       - name: Test for cmd
         shell: cmd
         run: |
-          set RUBY=${{steps.tool-versions.outputs.ruby}}
-          set NPM=${{steps.tool-versions.outputs.npm}}
-          set PYTHON=${{steps.tool-versions.outputs.python}}
+          set RUBY=${{steps.tool-versions.outputs.example-ruby}}
+          set NPM=${{steps.tool-versions.outputs.example-npm}}
+          set PYTHON=${{steps.tool-versions.outputs.example-python}}
           if "%RUBY%" == "" exit 1
           if "%NPM%" == "" exit 1
           if "%PYTHON%" == "" exit 1
@@ -60,9 +60,9 @@ jobs:
       - name: Test for powershell
         shell: powershell
         run: |
-          $Env:RUBY="${{steps.tool-versions.outputs.ruby}}"
-          $Env:NPM="${{steps.tool-versions.outputs.npm}}"
-          $Env:PYTHON="${{steps.tool-versions.outputs.python}}"
+          $Env:RUBY="${{steps.tool-versions.outputs.example-ruby}}"
+          $Env:NPM="${{steps.tool-versions.outputs.example-npm}}"
+          $Env:PYTHON="${{steps.tool-versions.outputs.example-python}}"
           Test-Path $Env:RUBY
           Test-Path $Env:NPM
           Test-Path $Env:PYTHON

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 # Example .tool-versions file, as used by CI (and the README) 
-ruby 2.5.3 # This is a comment
+example-ruby 2.5.3 # This is a comment
 # This is another comment
-npm 8.3.1
-python 3.7.2 2.7.15 system # Only 3.7.2 used
+example-npm 8.3.1
+example-python 3.7.2 2.7.15 system # Only 3.7.2 used


### PR DESCRIPTION
# Description

These properly signal they're an example (used in CI alone, kept as-was in the README) and prevent unwarranted updates from Renovate.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/parse-tool-versions/blob/main/CONTRIBUTING.md)
