### PR TITLE
Add partial support for `ref:v?`

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -30,9 +30,11 @@ jobs:
           RUBY=${{steps.tool-versions.outputs.example-ruby}}
           NPM=${{steps.tool-versions.outputs.example-npm}}
           PYTHON=${{steps.tool-versions.outputs.example-python}}
+          NODEJS=${{steps.tool-versions.outputs.example-nodejs}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"
+          echo "${NODEJS?output not set}"
 
       - name: Test for pwsh
         shell: pwsh
@@ -40,9 +42,11 @@ jobs:
           $Env:RUBY="${{steps.tool-versions.outputs.example-ruby}}"
           $Env:NPM="${{steps.tool-versions.outputs.example-npm}}"
           $Env:PYTHON="${{steps.tool-versions.outputs.example-python}}"
+          $Env:NODEJS="${{steps.tool-versions.outputs.example-nodejs}}"
           Test-Path $Env:RUBY
           Test-Path $Env:NPM
           Test-Path $Env:PYTHON
+          Test-Path $Env:NODEJS
 
       - name: Test for sh
         shell: sh
@@ -50,6 +54,8 @@ jobs:
           RUBY=${{steps.tool-versions.outputs.example-ruby}}
           NPM=${{steps.tool-versions.outputs.example-npm}}
           PYTHON=${{steps.tool-versions.outputs.example-python}}
+          NODEJS=${{steps.tool-versions.outputs.example-nodejs}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"
+          echo "${NODEJS?output not set}"

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -30,9 +30,11 @@ jobs:
           RUBY=${{steps.tool-versions.outputs.example-ruby}}
           NPM=${{steps.tool-versions.outputs.example-npm}}
           PYTHON=${{steps.tool-versions.outputs.example-python}}
+          NODEJS=${{steps.tool-versions.outputs.example-nodejs}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"
+          echo "${NODEJS?output not set}"
 
       - name: Test for pwsh
         shell: pwsh
@@ -40,9 +42,11 @@ jobs:
           $Env:RUBY="${{steps.tool-versions.outputs.example-ruby}}"
           $Env:NPM="${{steps.tool-versions.outputs.example-npm}}"
           $Env:PYTHON="${{steps.tool-versions.outputs.example-python}}"
+          $Env:NODEJS="${{steps.tool-versions.outputs.example-nodejs}}"
           Test-Path $Env:RUBY
           Test-Path $Env:NPM
           Test-Path $Env:PYTHON
+          Test-Path $Env:NODEJS
 
       - name: Test for sh
         shell: sh
@@ -50,6 +54,8 @@ jobs:
           RUBY=${{steps.tool-versions.outputs.example-ruby}}
           NPM=${{steps.tool-versions.outputs.example-npm}}
           PYTHON=${{steps.tool-versions.outputs.example-python}}
+          NODEJS=${{steps.tool-versions.outputs.example-nodejs}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"
+          echo "${NODEJS?output not set}"

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -30,9 +30,11 @@ jobs:
           RUBY=${{steps.tool-versions.outputs.example-ruby}}
           NPM=${{steps.tool-versions.outputs.example-npm}}
           PYTHON=${{steps.tool-versions.outputs.example-python}}
+          NODEJS=${{steps.tool-versions.outputs.example-nodejs}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"
+          echo "${NODEJS?output not set}"
 
       - name: Test for pwsh
         shell: pwsh
@@ -40,9 +42,11 @@ jobs:
           $Env:RUBY="${{steps.tool-versions.outputs.example-ruby}}"
           $Env:NPM="${{steps.tool-versions.outputs.example-npm}}"
           $Env:PYTHON="${{steps.tool-versions.outputs.example-python}}"
+          $Env:NODEJS="${{steps.tool-versions.outputs.example-nodejs}}"
           Test-Path $Env:RUBY
           Test-Path $Env:NPM
           Test-Path $Env:PYTHON
+          Test-Path $Env:NODEJS
 
       - name: Test for sh
         shell: sh
@@ -50,9 +54,11 @@ jobs:
           RUBY=${{steps.tool-versions.outputs.example-ruby}}
           NPM=${{steps.tool-versions.outputs.example-npm}}
           PYTHON=${{steps.tool-versions.outputs.example-python}}
+          NODEJS=${{steps.tool-versions.outputs.example-nodejs}}
           echo "${RUBY?output not set}"
           echo "${NPM?output not set}"
           echo "${PYTHON?output not set}"
+          echo "${NODEJS?output not set}"
 
       - name: Test for cmd
         shell: cmd
@@ -60,9 +66,11 @@ jobs:
           set RUBY=${{steps.tool-versions.outputs.example-ruby}}
           set NPM=${{steps.tool-versions.outputs.example-npm}}
           set PYTHON=${{steps.tool-versions.outputs.example-python}}
+          set NODEJS=${{steps.tool-versions.outputs.example-nodejs}}
           if "%RUBY%" == "" exit 1
           if "%NPM%" == "" exit 1
           if "%PYTHON%" == "" exit 1
+          if "%NODEJS%" == "" exit 1
 
       - name: Test for powershell
         shell: powershell
@@ -70,6 +78,8 @@ jobs:
           $Env:RUBY="${{steps.tool-versions.outputs.example-ruby}}"
           $Env:NPM="${{steps.tool-versions.outputs.example-npm}}"
           $Env:PYTHON="${{steps.tool-versions.outputs.example-python}}"
+          $Env:NODEJS="${{steps.tool-versions.outputs.example-nodejs}}"
           Test-Path $Env:RUBY
           Test-Path $Env:NPM
           Test-Path $Env:PYTHON
+          Test-Path $Env:NODEJS

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,3 +3,4 @@ example-ruby 2.5.3 # This is a comment
 # This is another comment
 example-npm 8.3.1
 example-python 3.7.2 2.7.15 system # Only 3.7.2 used
+example-nodejs ref:v3.22.0

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -2809,10 +2809,10 @@ function parse() {
   console.log(`File: ${dotToolVersionsPath}`);
   const versions = external_fs_.readFileSync(dotToolVersionsPath, 'utf8');
   versions.split('\n').forEach((line) => {
-    const appVersion = line.match(/^([^ #]+)[ ]+([^ #\r\n]+)/);
+    const appVersion = line.match(/^([^ #]+)[ ]+(ref:v?)?([^ #\r\n]+)/);
     if (appVersion) {
       const app = appVersion[1];
-      const [, , version] = appVersion;
+      const [, , , version] = appVersion;
       appVersions.set(app, version);
       console.log(`Consuming ${app} at version ${version}`);
     }

--- a/src/parse_tool_versions.mjs
+++ b/src/parse_tool_versions.mjs
@@ -19,10 +19,10 @@ function parse() {
   console.log(`File: ${dotToolVersionsPath}`);
   const versions = fs.readFileSync(dotToolVersionsPath, 'utf8');
   versions.split('\n').forEach((line) => {
-    const appVersion = line.match(/^([^ #]+)[ ]+([^ #\r\n]+)/);
+    const appVersion = line.match(/^([^ #]+)[ ]+(ref:v?)?([^ #\r\n]+)/);
     if (appVersion) {
       const app = appVersion[1];
-      const [, , version] = appVersion;
+      const [, , , version] = appVersion;
       appVersions.set(app, version);
       console.log(`Consuming ${app} at version ${version}`);
     }


### PR DESCRIPTION
# Description

If you pass either:
- `ref:<version>`, or
- `ref:v<version>` we deliver, as an output, the version from whatever follows it

(inspiration for this came from https://github.com/erlef/setup-beam)

Closes #9.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/parse-tool-versions/blob/main/CONTRIBUTING.md)
